### PR TITLE
add travis linting support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+install:
+  - "pip install -r requirements.txt"
+  - "pip install pycodestyle"
+script:
+  - pycodestyle .


### PR DESCRIPTION
apparently pycodestyle replaced pep8, who knew