### PR TITLE
Pin watson-developer-cloud SDK to prevent breakage.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-dotenv==0.8.2
 Flask
-watson_developer_cloud
+watson_developer_cloud==1.5


### PR DESCRIPTION
The 2.0 version of Watson python SDK contains breaking changes.
Pin the version for now, and provide fixes in a later patch.